### PR TITLE
fix: run E2E tests in parallel with CI (#48)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    needs: [ci]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
**What**: Remove `needs: [ci]` dependency from E2E job.

**Why**: E2E builds its own Docker image and doesn't depend on CI artifacts — running sequentially adds ~4-5 min unnecessary wait.

**How**: Remove `needs: [ci]` line.

**Spec**: N/A (CI config fix).

Closes #48