### PR TITLE
fix: add missing Cargo.toml metadata for crates.io (#51)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,11 @@ name = "modbus-exporter"
 version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
+description = "A Modbus RTU/TCP to OpenTelemetry metrics exporter with Prometheus scrape endpoint"
+repository = "https://github.com/r12f/modbus-exporter"
+homepage = "https://github.com/r12f/modbus-exporter"
+keywords = ["modbus", "opentelemetry", "prometheus", "metrics", "exporter"]
+categories = ["network-programming"]
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
**What**: Add missing `description`, `repository`, `homepage`, `keywords`, `categories` to Cargo.toml.

**Why**: crates.io rejects publish without `description` field (400 Bad Request).

**How**: Add metadata fields.

**Spec**: N/A.

Closes #51.