### PR TITLE
feat: config file fallback search path and relative path resolution (#53)

### DIFF
--- a/spec/config.md
+++ b/spec/config.md
@@ -2,7 +2,25 @@
 
 ## Overview
 
-Configuration is loaded from a YAML file specified via `--config` CLI flag. Default: `config.yaml` in the working directory.
+Configuration is loaded from a YAML file. The file location is determined as follows:
+
+### Config File Resolution
+
+If `--config <path>` is specified, use that path exactly (error if not found).
+
+If `--config` is **not** specified, search in order (first match wins):
+
+1. `./config.yaml` (current working directory — highest priority)
+2. `~/.config/modbus-exporter/config.yaml` (user config)
+3. `/etc/modbus-exporter/config.yaml` (system config)
+
+If none found, exit with an error listing all searched paths.
+
+### Path Resolution
+
+All relative paths within the config file (e.g., `metrics_files` entries) are resolved relative to the **parent directory of the config file that was loaded**, not the current working directory.
+
+Example: config loaded from `~/.config/modbus-exporter/config.yaml` with `metrics_files: ["devices/sdm630.yaml"]` → resolves to `~/.config/modbus-exporter/devices/sdm630.yaml`.
 
 ## Example
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,8 +12,43 @@ use tracing::info;
 #[command(name = "modbus-exporter")]
 pub struct Cli {
     /// Path to the configuration file
-    #[arg(short, long, default_value = "config.yaml")]
-    pub config: PathBuf,
+    #[arg(short, long)]
+    pub config: Option<PathBuf>,
+}
+
+/// Default search paths for the config file (in priority order).
+pub const CONFIG_SEARCH_PATHS: &[&str] = &[
+    "./config.yaml",
+    "~/.config/modbus-exporter/config.yaml",
+    "/etc/modbus-exporter/config.yaml",
+];
+
+/// Find the config file using the fallback search order.
+/// If `explicit` is Some, use that exact path (error if missing).
+/// Otherwise search the default locations.
+pub fn find_config_file(explicit: Option<&Path>) -> Result<PathBuf> {
+    if let Some(p) = explicit {
+        if p.exists() {
+            return Ok(p.to_path_buf());
+        }
+        bail!("specified config file not found: {}", p.display());
+    }
+
+    let home = std::env::var("HOME").unwrap_or_default();
+    for pattern in CONFIG_SEARCH_PATHS {
+        let expanded = pattern.replace('~', &home);
+        let path = PathBuf::from(&expanded);
+        if path.exists() {
+            info!(path = %path.display(), "found config file");
+            return Ok(path);
+        }
+    }
+
+    let searched: Vec<String> = CONFIG_SEARCH_PATHS
+        .iter()
+        .map(|p| p.replace('~', &home))
+        .collect();
+    bail!("no config file found; searched:\n{}", searched.join("\n"));
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/config_tests.rs
+++ b/src/config_tests.rs
@@ -1023,6 +1023,100 @@ collectors:
     .to_string()
 }
 
+// ── Config search path tests ──────────────────────────────────────────
+
+#[test]
+fn find_config_explicit_path_exists() {
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = dir.path().join("my.yaml");
+    std::fs::write(&cfg, "").unwrap();
+    let result = find_config_file(Some(cfg.as_path()));
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), cfg);
+}
+
+#[test]
+fn find_config_explicit_path_missing() {
+    let result = find_config_file(Some(Path::new("/nonexistent/config.yaml")));
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("specified config file not found"), "{msg}");
+}
+
+#[test]
+fn find_config_fallback_cwd() {
+    let dir = tempfile::tempdir().unwrap();
+    let old_dir = std::env::current_dir().unwrap();
+    std::fs::write(dir.path().join("config.yaml"), "").unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+    let result = find_config_file(None);
+    std::env::set_current_dir(&old_dir).unwrap();
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), PathBuf::from("./config.yaml"));
+}
+
+#[test]
+fn find_config_fallback_none_found() {
+    let dir = tempfile::tempdir().unwrap();
+    let old_dir = std::env::current_dir().unwrap();
+    // empty dir, no config.yaml
+    std::env::set_current_dir(dir.path()).unwrap();
+    // Override HOME so ~/.config path won't match
+    let old_home = std::env::var("HOME").ok();
+    std::env::set_var("HOME", dir.path());
+    let result = find_config_file(None);
+    std::env::set_current_dir(&old_dir).unwrap();
+    if let Some(h) = old_home {
+        std::env::set_var("HOME", h);
+    }
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("no config file found"), "{msg}");
+}
+
+#[test]
+fn resolve_metrics_files_relative_to_config_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    let metrics_dir = dir.path().join("metrics");
+    std::fs::create_dir_all(&metrics_dir).unwrap();
+    let metrics_file = metrics_dir.join("test.yaml");
+    std::fs::write(
+        &metrics_file,
+        r#"
+metrics:
+  - name: temp
+    type: gauge
+    register_type: holding
+    address: 0
+    data_type: u16
+"#,
+    )
+    .unwrap();
+
+    let config_yaml = format!(
+        r#"
+exporters:
+  prometheus:
+    enabled: true
+collectors:
+  - name: test
+    protocol:
+      type: tcp
+      endpoint: "localhost:502"
+    slave_id: 1
+    metrics_files:
+      - metrics/test.yaml
+    metrics: []
+"#
+    );
+
+    let config_path = dir.path().join("config.yaml");
+    std::fs::write(&config_path, &config_yaml).unwrap();
+    let config = Config::load(&config_path).unwrap();
+    assert_eq!(config.collectors[0].metrics.len(), 1);
+    assert_eq!(config.collectors[0].metrics[0].name, "temp");
+}
+
 #[test]
 fn test_parse_mqtt_minimal() {
     let c = parse(&mqtt_yaml()).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
 use collector::{CollectorEngine, ModbusClientFactory, DEFAULT_SHUTDOWN_TIMEOUT};
-use config::{Cli, Config, Protocol};
+use config::{find_config_file, Cli, Config, Protocol};
 use internal_metrics::InternalMetrics;
 use logging::{init_logging, LogOutput, LoggingConfig};
 use metrics::MetricStore;
@@ -116,8 +116,10 @@ async fn main() -> Result<()> {
     // 1. Parse CLI
     let cli = Cli::parse();
 
-    // 2. Load config
-    let config = Config::load(&cli.config).context("failed to load configuration")?;
+    // 2. Find and load config
+    let config_path =
+        find_config_file(cli.config.as_deref()).context("failed to find configuration file")?;
+    let config = Config::load(&config_path).context("failed to load configuration")?;
 
     // 3. Init logging
     let logging_cfg = map_logging_config(&config.logging);


### PR DESCRIPTION
**What**: Config file search order (CWD → ~/.config → /etc) + metrics_files paths resolve relative to config dir.

**Why**: Better UX — users don't need to always specify --config, and metrics files work correctly regardless of CWD.

**How**: Search path fallback in config loading, path resolution using config file parent dir.

**Spec**: See updated `spec/config.md`.

Closes #53.