### PR TITLE
ci: pause E2E job (Docker Hub rate limit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
 
   e2e:
+    if: false # Paused: Docker Hub rate-limiting oitc/modbus-server pulls
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
Pauses E2E CI job with `if: false`. Docker Hub is rate-limiting pulls of `oitc/modbus-server`, causing all E2E runs to fail. Re-enable when resolved.