### PR TITLE
refactor: rename protocol types tcp/rtu → modbus-tcp/modbus-rtu

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ exporters:
 collectors:
   - name: "power-meter"
     protocol:
-      type: tcp
+      type: modbus-tcp
       endpoint: "192.168.1.100:502"
     slave_id: 1
     polling_interval: "5s"

--- a/config.yaml
+++ b/config.yaml
@@ -44,7 +44,7 @@ collectors:
   # ---- TCP example --------------------------------------------------------
   - name: plc-east
     protocol:
-      type: tcp
+      type: modbus-tcp
       endpoint: "192.168.1.10:502"
     slave_id: 1
     poll_interval: 5s
@@ -90,7 +90,7 @@ collectors:
   # ---- RTU example (commented out) ----------------------------------------
   # - name: inverter-south
   #   protocol:
-  #     type: rtu
+  #     type: modbus-rtu
   #     port: /dev/ttyUSB0
   #     baud_rate: 9600
   #     data_bits: 8

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -25,7 +25,7 @@ exporters:
 collectors:
   - name: solar_inverter
     protocol:
-      type: tcp
+      type: modbus-tcp
       endpoint: "192.168.1.10:502"
     slave_id: 1
     polling_interval: "5s"
@@ -55,7 +55,7 @@ collectors:
 
   - name: power_meter
     protocol:
-      type: rtu
+      type: modbus-rtu
       device: "/dev/ttyUSB0"
       bps: 19200
       data_bits: 8

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -21,7 +21,7 @@ exporters:
 collectors:
   - name: test_device
     protocol:
-      type: tcp
+      type: modbus-tcp
       endpoint: "modbus-simulator:5020"
     slave_id: 1
     polling_interval: "2s"

--- a/spec/config.md
+++ b/spec/config.md
@@ -109,14 +109,14 @@ A collector must have at least one metric after merging `metrics_files` and `met
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `type` | `string` | Yes | — | Must be `"tcp"` |
+| `type` | `string` | Yes | — | Must be `"modbus-tcp"` |
 | `endpoint` | `string` | Yes | — | `host:port` |
 
 #### RTU
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `type` | `string` | Yes | — | Must be `"rtu"` |
+| `type` | `string` | Yes | — | Must be `"modbus-rtu"` |
 | `device` | `string` | Yes | — | Serial device path (e.g., `/dev/ttyUSB0`) |
 | `bps` | `u32` | No | `9600` | Baud rate |
 | `data_bits` | `u8` | No | `8` | Data bits (5-8) |
@@ -215,7 +215,7 @@ metrics:
 # config.yaml
 collectors:
   - name: meter1
-    protocol: { type: tcp, endpoint: "192.168.1.10:502" }
+    protocol: { type: modbus-tcp, endpoint: "192.168.1.10:502" }
     slave_id: 1
     metrics_files:
       - "devices/base.yaml"       # loaded first

--- a/src/collector_tests.rs
+++ b/src/collector_tests.rs
@@ -106,7 +106,7 @@ impl ModbusReader for MockModbusClient {
 fn test_collector_config(name: &str) -> Collector {
     Collector {
         name: name.to_string(),
-        protocol: Protocol::Tcp {
+        protocol: Protocol::ModbusTcp {
             endpoint: "127.0.0.1:502".to_string(),
         },
         slave_id: 1,

--- a/src/config.rs
+++ b/src/config.rs
@@ -252,12 +252,12 @@ fn default_polling_interval() -> Duration {
 }
 
 #[derive(Debug, Deserialize, Clone)]
-#[serde(tag = "type", rename_all = "lowercase")]
+#[serde(tag = "type")]
 pub enum Protocol {
-    Tcp {
-        endpoint: String,
-    },
-    Rtu {
+    #[serde(rename = "modbus-tcp")]
+    ModbusTcp { endpoint: String },
+    #[serde(rename = "modbus-rtu")]
+    ModbusRtu {
         device: String,
         #[serde(default = "default_bps")]
         bps: u32,
@@ -639,7 +639,7 @@ impl Config {
                 );
             }
             // Validate TCP endpoint format (must be parseable as host:port)
-            if let Protocol::Tcp { endpoint } = &c.protocol {
+            if let Protocol::ModbusTcp { endpoint } = &c.protocol {
                 // Must contain at least one colon separating host from port,
                 // and the port part must be a valid u16.
                 let valid = endpoint
@@ -654,7 +654,7 @@ impl Config {
                 }
             }
             // Validate RTU data_bits and stop_bits ranges
-            if let Protocol::Rtu {
+            if let Protocol::ModbusRtu {
                 data_bits,
                 stop_bits,
                 ..

--- a/src/config_tests.rs
+++ b/src/config_tests.rs
@@ -9,7 +9,7 @@ exporters:
 collectors:
   - name: test
     protocol:
-      type: tcp
+      type: modbus-tcp
       endpoint: "localhost:502"
     slave_id: 1
     metrics:
@@ -65,7 +65,7 @@ exporters:
 collectors:
   - name: inv
     protocol:
-      type: tcp
+      type: modbus-tcp
       endpoint: "192.168.1.10:502"
     slave_id: 1
     polling_interval: "5s"
@@ -84,7 +84,7 @@ collectors:
         unit: "V"
   - name: meter
     protocol:
-      type: rtu
+      type: modbus-rtu
       device: "/dev/ttyUSB0"
       bps: 19200
       data_bits: 8
@@ -105,7 +105,7 @@ collectors:
     assert_eq!(c.logging.syslog_facility, SyslogFacility::Local0);
     assert_eq!(c.collectors.len(), 2);
     match &c.collectors[1].protocol {
-        Protocol::Rtu { bps, parity, .. } => {
+        Protocol::ModbusRtu { bps, parity, .. } => {
             assert_eq!(*bps, 19200);
             assert_eq!(*parity, Parity::Even);
         }
@@ -121,7 +121,7 @@ exporters:
     enabled: false
 collectors:
   - name: t
-    protocol: { type: tcp, endpoint: "localhost:502" }
+    protocol: { type: modbus-tcp, endpoint: "localhost:502" }
     slave_id: 1
     metrics:
       - { name: v, type: gauge, register_type: holding, address: 0, data_type: u16 }
@@ -148,11 +148,11 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: d
-    protocol: { type: tcp, endpoint: "a:502" }
+    protocol: { type: modbus-tcp, endpoint: "a:502" }
     slave_id: 1
     metrics: [{ name: v, type: gauge, register_type: holding, address: 0, data_type: u16 }]
   - name: d
-    protocol: { type: tcp, endpoint: "b:502" }
+    protocol: { type: modbus-tcp, endpoint: "b:502" }
     slave_id: 2
     metrics: [{ name: v, type: gauge, register_type: holding, address: 0, data_type: u16 }]
 "#;
@@ -178,7 +178,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: t
-    protocol: { type: tcp, endpoint: "a:502" }
+    protocol: { type: modbus-tcp, endpoint: "a:502" }
     slave_id: 1
     metrics:
       - { name: m, type: gauge, register_type: coil, address: 0, data_type: u16 }
@@ -196,7 +196,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: t
-    protocol: { type: tcp, endpoint: "a:502" }
+    protocol: { type: modbus-tcp, endpoint: "a:502" }
     slave_id: 1
     metrics:
       - { name: m, type: gauge, register_type: holding, address: 0, data_type: bool }
@@ -214,7 +214,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: t
-    protocol: { type: tcp, endpoint: "a:502" }
+    protocol: { type: modbus-tcp, endpoint: "a:502" }
     slave_id: 1
     metrics:
       - { name: d, type: gauge, register_type: holding, address: 0, data_type: u16 }
@@ -236,7 +236,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: t
-    protocol: { type: tcp, endpoint: "a:502" }
+    protocol: { type: modbus-tcp, endpoint: "a:502" }
     slave_id: 1
     metrics: []
 "#;
@@ -253,7 +253,7 @@ exporters:
   otlp: { enabled: true }
 collectors:
   - name: t
-    protocol: { type: tcp, endpoint: "a:502" }
+    protocol: { type: modbus-tcp, endpoint: "a:502" }
     slave_id: 1
     metrics:
       - { name: v, type: gauge, register_type: holding, address: 0, data_type: u16 }
@@ -279,14 +279,14 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: t
-    protocol: { type: rtu, device: "/dev/ttyUSB0" }
+    protocol: { type: modbus-rtu, device: "/dev/ttyUSB0" }
     slave_id: 1
     metrics:
       - { name: c, type: gauge, register_type: coil, address: 0, data_type: bool }
 "#;
     let c = parse(y).unwrap();
     match &c.collectors[0].protocol {
-        Protocol::Rtu {
+        Protocol::ModbusRtu {
             bps,
             data_bits,
             stop_bits,
@@ -311,7 +311,7 @@ exporters:
   prometheus: {{ enabled: true }}
 collectors:
   - name: t
-    protocol: {{ type: tcp, endpoint: "a:502" }}
+    protocol: {{ type: modbus-tcp, endpoint: "a:502" }}
     slave_id: 1
     metrics:
       - {{ name: m, type: gauge, register_type: holding, address: 0, data_type: {dt} }}
@@ -335,7 +335,7 @@ exporters:
   prometheus: {{ enabled: true }}
 collectors:
   - name: t
-    protocol: {{ type: tcp, endpoint: "a:502" }}
+    protocol: {{ type: modbus-tcp, endpoint: "a:502" }}
     slave_id: 1
     metrics:
       - {{ name: m, type: gauge, register_type: holding, address: 0, data_type: u32, byte_order: {bo} }}
@@ -357,7 +357,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: t
-    protocol: { type: tcp, endpoint: "a:502" }
+    protocol: { type: modbus-tcp, endpoint: "a:502" }
     slave_id: 1
     metrics:
       - { name: v, type: gauge, register_type: holding, address: 0, data_type: u16 }
@@ -374,7 +374,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: t
-    protocol: { type: tcp, endpoint: "a:502" }
+    protocol: { type: modbus-tcp, endpoint: "a:502" }
     slave_id: 1
     metrics:
       - { name: v, type: gauge, register_type: holding, address: 0, data_type: u16 }
@@ -391,7 +391,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: t
-    protocol: { type: tcp, endpoint: "a:502" }
+    protocol: { type: modbus-tcp, endpoint: "a:502" }
     slave_id: 1
     metrics:
       - { name: v, type: gauge, register_type: holding, address: 0, data_type: u16 }
@@ -413,7 +413,7 @@ exporters:
   prometheus: {{ enabled: true }}
 collectors:
   - name: t
-    protocol: {{ type: tcp, endpoint: "a:502" }}
+    protocol: {{ type: modbus-tcp, endpoint: "a:502" }}
     slave_id: 1
     metrics:
       - {{ name: v, type: gauge, register_type: holding, address: 0, data_type: u16 }}
@@ -436,7 +436,7 @@ exporters:
   prometheus: {{ enabled: true }}
 collectors:
   - name: t
-    protocol: {{ type: tcp, endpoint: "a:502" }}
+    protocol: {{ type: modbus-tcp, endpoint: "a:502" }}
     slave_id: 1
     metrics:
       - {{ name: v, type: gauge, register_type: holding, address: 0, data_type: u16 }}
@@ -453,7 +453,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: t
-    protocol: { type: rtu, device: "/dev/ttyUSB0", data_bits: 4 }
+    protocol: { type: modbus-rtu, device: "/dev/ttyUSB0", data_bits: 4 }
     slave_id: 1
     metrics:
       - { name: c, type: gauge, register_type: coil, address: 0, data_type: bool }
@@ -471,7 +471,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: t
-    protocol: { type: rtu, device: "/dev/ttyUSB0", stop_bits: 3 }
+    protocol: { type: modbus-rtu, device: "/dev/ttyUSB0", stop_bits: 3 }
     slave_id: 1
     metrics:
       - { name: c, type: gauge, register_type: coil, address: 0, data_type: bool }
@@ -489,7 +489,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: t
-    protocol: { type: tcp, endpoint: "a:502" }
+    protocol: { type: modbus-tcp, endpoint: "a:502" }
     slave_id: 1
     metrics:
       - { name: v, type: gauge, register_type: holding, address: 0, data_type: u16, scale: 0.0 }
@@ -507,7 +507,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: t
-    protocol: { type: tcp, endpoint: "a:502" }
+    protocol: { type: modbus-tcp, endpoint: "a:502" }
     slave_id: 1
     polling_interval: "0s"
     metrics:
@@ -526,7 +526,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: t
-    protocol: { type: tcp, endpoint: "a:502" }
+    protocol: { type: modbus-tcp, endpoint: "a:502" }
     slave_id: 1
     polling_interval: "50ms"
     metrics:
@@ -545,7 +545,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: t
-    protocol: { type: tcp, endpoint: "a:502" }
+    protocol: { type: modbus-tcp, endpoint: "a:502" }
     slave_id: 1
     polling_interval: "100ms"
     metrics:
@@ -561,7 +561,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: t
-    protocol: { type: tcp, endpoint: "a:502" }
+    protocol: { type: modbus-tcp, endpoint: "a:502" }
     slave_id: 1
     metrics:
       - { name: m, type: counter, register_type: coil, address: 0, data_type: bool }
@@ -579,7 +579,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: t
-    protocol: { type: tcp, endpoint: "a:502" }
+    protocol: { type: modbus-tcp, endpoint: "a:502" }
     slave_id: 1
     metrics:
       - { name: m, type: counter, register_type: discrete, address: 0, data_type: bool }
@@ -597,7 +597,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: t
-    protocol: { type: tcp, endpoint: "a:502" }
+    protocol: { type: modbus-tcp, endpoint: "a:502" }
     slave_id: 1
     metrics:
       - { name: m, type: gauge, register_type: holding, address: 65535, data_type: u32 }
@@ -612,7 +612,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: t
-    protocol: { type: tcp, endpoint: "a:502" }
+    protocol: { type: modbus-tcp, endpoint: "a:502" }
     slave_id: 1
     metrics:
       - { name: m, type: gauge, register_type: holding, address: 65533, data_type: u64 }
@@ -628,7 +628,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: t
-    protocol: { type: tcp, endpoint: "a:502" }
+    protocol: { type: modbus-tcp, endpoint: "a:502" }
     slave_id: 1
     metrics:
       - { name: m, type: gauge, register_type: holding, address: 65534, data_type: u32 }
@@ -644,7 +644,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: t
-    protocol: { type: tcp, endpoint: "a:502" }
+    protocol: { type: modbus-tcp, endpoint: "a:502" }
     slave_id: 1
     metrics:
       - { name: m, type: gauge, register_type: holding, address: 65535, data_type: u16 }
@@ -693,7 +693,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: test
-    protocol: { type: tcp, endpoint: "localhost:502" }
+    protocol: { type: modbus-tcp, endpoint: "localhost:502" }
     slave_id: 1
     metrics_files:
       - "devices/meter.yaml"
@@ -750,7 +750,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: test
-    protocol: { type: tcp, endpoint: "localhost:502" }
+    protocol: { type: modbus-tcp, endpoint: "localhost:502" }
     slave_id: 1
     metrics_files:
       - "base.yaml"
@@ -799,7 +799,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: test
-    protocol: { type: tcp, endpoint: "localhost:502" }
+    protocol: { type: modbus-tcp, endpoint: "localhost:502" }
     slave_id: 1
     metrics_files:
       - "meter.yaml"
@@ -854,7 +854,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: test
-    protocol: { type: tcp, endpoint: "localhost:502" }
+    protocol: { type: modbus-tcp, endpoint: "localhost:502" }
     slave_id: 1
     metrics_files:
       - "base.yaml"
@@ -889,7 +889,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: test
-    protocol: { type: tcp, endpoint: "localhost:502" }
+    protocol: { type: modbus-tcp, endpoint: "localhost:502" }
     slave_id: 1
     metrics_files:
       - "subdir/devices/meter.yaml"
@@ -907,7 +907,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: test
-    protocol: { type: tcp, endpoint: "localhost:502" }
+    protocol: { type: modbus-tcp, endpoint: "localhost:502" }
     slave_id: 1
     metrics_files:
       - "nonexistent.yaml"
@@ -930,7 +930,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: test
-    protocol: { type: tcp, endpoint: "localhost:502" }
+    protocol: { type: modbus-tcp, endpoint: "localhost:502" }
     slave_id: 1
     metrics_files:
       - "empty.yaml"
@@ -974,7 +974,7 @@ exporters:
   prometheus: { enabled: true }
 collectors:
   - name: test
-    protocol: { type: tcp, endpoint: "localhost:502" }
+    protocol: { type: modbus-tcp, endpoint: "localhost:502" }
     slave_id: 1
     metrics_files:
       - "meter.yaml"
@@ -1010,7 +1010,7 @@ exporters:
 collectors:
   - name: test
     protocol:
-      type: tcp
+      type: modbus-tcp
       endpoint: "localhost:502"
     slave_id: 1
     metrics:
@@ -1101,7 +1101,7 @@ exporters:
 collectors:
   - name: test
     protocol:
-      type: tcp
+      type: modbus-tcp
       endpoint: "localhost:502"
     slave_id: 1
     metrics_files:
@@ -1153,7 +1153,7 @@ exporters:
 collectors:
   - name: test
     protocol:
-      type: tcp
+      type: modbus-tcp
       endpoint: "localhost:502"
     slave_id: 1
     metrics:
@@ -1187,7 +1187,7 @@ exporters:
 collectors:
   - name: test
     protocol:
-      type: tcp
+      type: modbus-tcp
       endpoint: "localhost:502"
     slave_id: 1
     metrics:
@@ -1215,7 +1215,7 @@ exporters:
 collectors:
   - name: test
     protocol:
-      type: tcp
+      type: modbus-tcp
       endpoint: "localhost:502"
     slave_id: 1
     metrics:

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,10 +30,10 @@ struct RealModbusClientFactory;
 impl ModbusClientFactory for RealModbusClientFactory {
     fn create(&self, collector: &config::Collector) -> Box<dyn modbus::ModbusClient> {
         match &collector.protocol {
-            Protocol::Tcp { endpoint } => {
+            Protocol::ModbusTcp { endpoint } => {
                 Box::new(TcpClient::new(endpoint.clone(), collector.slave_id))
             }
-            Protocol::Rtu {
+            Protocol::ModbusRtu {
                 device,
                 bps,
                 data_bits,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -21,7 +21,7 @@ exporters:
 collectors:
   - name: dev1
     protocol:
-      type: tcp
+      type: modbus-tcp
       endpoint: "127.0.0.1:502"
     slave_id: 1
     polling_interval: "1s"
@@ -60,7 +60,7 @@ exporters:
 collectors:
   - name: dev1
     protocol:
-      type: tcp
+      type: modbus-tcp
       endpoint: "127.0.0.1:502"
     slave_id: 1
     polling_interval: "1s"


### PR DESCRIPTION
**What**: Renames protocol type values from `tcp`/`rtu` to `modbus-tcp`/`modbus-rtu` in config YAML and code.

**Why**: Preparing for I2C/SPI support — `tcp` and `rtu` are ambiguous when multiple bus protocols exist.

**How**: Updated `Protocol` enum variants (`Tcp` → `ModbusTcp`, `Rtu` → `ModbusRtu`) with serde rename attributes. Updated all YAML configs, tests, specs, and docs. All 304 tests pass.