### PR TITLE
fix: lower minimum polling_interval to 1ms

### DIFF
--- a/spec/config.md
+++ b/spec/config.md
@@ -261,7 +261,7 @@ logging:
 11. All `metrics_files` paths must exist and be readable.
 12. Each metrics file must contain a valid `metrics` list with at least one entry.
 13. After merge, all required fields (`name`, `type`, `register_type`, `address`, `data_type`) must be present on every metric. Missing required fields from partial overrides are a validation error.
-14. `polling_interval` must be ≥ 100ms.
+14. `polling_interval` must be ≥ 1ms.
 15. `scale` must not be zero.
 16. `counter` metric type is not compatible with `coil`/`discrete` register types or `bool` data type (counters must be numeric).
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -630,10 +630,10 @@ impl Config {
                     c.slave_id
                 );
             }
-            // Validate polling_interval minimum (100ms)
-            if c.polling_interval.as_millis() < 100 {
+            // Validate polling_interval minimum (1ms)
+            if c.polling_interval.as_millis() < 1 {
                 bail!(
-                    "collector '{}': polling_interval must be at least 100ms, got {:?}",
+                    "collector '{}': polling_interval must be at least 1ms, got {:?}",
                     c.name,
                     c.polling_interval
                 );

--- a/src/config_tests.rs
+++ b/src/config_tests.rs
@@ -516,7 +516,7 @@ collectors:
     assert!(parse(y)
         .unwrap_err()
         .to_string()
-        .contains("polling_interval must be at least 100ms"));
+        .contains("polling_interval must be at least 1ms"));
 }
 
 #[test]
@@ -528,18 +528,18 @@ collectors:
   - name: t
     protocol: { type: modbus-tcp, endpoint: "a:502" }
     slave_id: 1
-    polling_interval: "50ms"
+    polling_interval: "0ms"
     metrics:
       - { name: v, type: gauge, register_type: holding, address: 0, data_type: u16 }
 "#;
     assert!(parse(y)
         .unwrap_err()
         .to_string()
-        .contains("polling_interval must be at least 100ms"));
+        .contains("polling_interval must be at least 1ms"));
 }
 
 #[test]
-fn test_polling_interval_100ms_ok() {
+fn test_polling_interval_1ms_ok() {
     let y = r#"
 exporters:
   prometheus: { enabled: true }
@@ -547,7 +547,7 @@ collectors:
   - name: t
     protocol: { type: modbus-tcp, endpoint: "a:502" }
     slave_id: 1
-    polling_interval: "100ms"
+    polling_interval: "1ms"
     metrics:
       - { name: v, type: gauge, register_type: holding, address: 0, data_type: u16 }
 "#;


### PR DESCRIPTION
Lower the minimum allowed polling_interval from 100ms to 1ms to support fast SPI/I2C ADC sampling use cases where sub-100ms polling is required.

Changes:
- src/config.rs: validation check from `< 100` to `< 1` ms, updated error message
- src/config_tests.rs: updated tests to reflect 1ms minimum
- spec/config.md: updated validation rule documentation