### PR TITLE
fix: update spec references for protocol rename and new modules

### DIFF
--- a/spec/config.md
+++ b/spec/config.md
@@ -105,14 +105,14 @@ A collector must have at least one metric after merging `metrics_files` and `met
 
 ### Protocol
 
-#### TCP
+#### Modbus TCP
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `type` | `string` | Yes | — | Must be `"modbus-tcp"` |
 | `endpoint` | `string` | Yes | — | `host:port` |
 
-#### RTU
+#### Modbus RTU
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|

--- a/spec/modbus.md
+++ b/spec/modbus.md
@@ -4,14 +4,14 @@
 
 The Modbus module provides async clients for RTU (serial) and TCP protocols, abstracting the differences behind a common trait.
 
-## RTU Client
+## Modbus RTU Client
 
 - Uses `tokio-serial` for async serial port access.
 - Configuration: device path, baud rate, data bits, stop bits, parity.
 - Uses `tokio-modbus` `rtu::connect_slave()` with the serial stream.
 - Only one outstanding request at a time per serial port (Modbus RTU is half-duplex).
 
-## TCP Client
+## Modbus TCP Client
 
 - Uses `tokio-modbus` `tcp::connect_slave()` with the target endpoint.
 - One TCP connection per collector.

--- a/spec/project-structure.md
+++ b/spec/project-structure.md
@@ -46,6 +46,12 @@ bus-exporter/
 │   │   ├── tcp_tests.rs
 │   │   ├── rtu.rs               # RTU client impl
 │   │   └── rtu_tests.rs
+│   ├── i2c/
+│   │   ├── mod.rs              # I2C client impl
+│   │   └── mod_tests.rs
+│   ├── spi/
+│   │   ├── mod.rs              # SPI client impl
+│   │   └── mod_tests.rs
 │   ├── decoder.rs               # Byte order reordering, type conversion, scale/offset
 │   ├── decoder_tests.rs
 │   ├── logging.rs               # Tracing subscriber init, output layer setup


### PR DESCRIPTION
- Rename RTU Client/TCP Client headers to Modbus RTU Client/Modbus TCP Client in spec/modbus.md
- Add I2C and SPI module entries to spec/project-structure.md
- Stage existing header fixes in spec/config.md