### PR TITLE
ci: add Docker build verification to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,21 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Run native E2E tests
         run: cargo test --test e2e_modbus -- --nocapture
+
+  docker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build Docker image (amd64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          load: true
+          tags: bus-exporter:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Verify Docker image runs
+        run: docker run --rm bus-exporter:ci --help


### PR DESCRIPTION
Adds a `docker` job to CI that builds the Docker image (amd64) and verifies it runs. Catches musl/Alpine build failures like the ioctl issue in PR #79 before merge.

- Uses `docker/build-push-action@v6` with BuildKit cache (GHA)
- Build only, no push (`push: false`, `load: true`)
- Smoke test: `docker run --rm bus-exporter:ci --help`