### PR TITLE
Switch Docker base image to distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ WORKDIR /src
 COPY . .
 RUN cargo build --release
 
-FROM alpine:3.20
-RUN apk add --no-cache ca-certificates
+FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=builder /src/target/release/bus-exporter /usr/local/bin/
 EXPOSE 9090
 HEALTHCHECK NONE

--- a/spec/docker.md
+++ b/spec/docker.md
@@ -14,9 +14,10 @@ RUN cargo build --release
 
 ### Runtime Stage
 
+Uses [Google's distroless](https://github.com/GoogleContainerTools/distroless) base image for a minimal, secure runtime with no shell or package manager. The `nonroot` tag runs as a non-root user by default. Since the binary is statically linked (musl), no additional system libraries are needed.
+
 ```dockerfile
-FROM alpine:3.20
-RUN apk add --no-cache ca-certificates
+FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=builder /src/target/release/bus-exporter /usr/local/bin/
 ENTRYPOINT ["bus-exporter"]
 CMD ["--config", "/etc/bus-exporter/config.yaml"]


### PR DESCRIPTION
## What
Switch the Docker runtime base image from `alpine:3.20` to `gcr.io/distroless/static-debian12:nonroot`.

## Why
- **Smaller attack surface**: Distroless images contain only the application binary — no shell, package manager, or OS utilities
- **Smaller image size**: `static-debian12` is ~2MB vs alpine's ~7MB base
- **Non-root by default**: The `nonroot` tag runs as UID 65534, improving security posture
- **CA certificates included**: `distroless/static` bundles CA certs, so the explicit `apk add ca-certificates` is no longer needed

## How
- Changed runtime stage `FROM` to `gcr.io/distroless/static-debian12:nonroot`
- Removed `RUN apk add --no-cache ca-certificates` (included in distroless/static)
- Build stage unchanged (`rust:alpine` with musl = static binary)
- Updated `spec/docker.md` to document the new base image

## Testing
- Binary is statically linked via musl — verified compatible with distroless/static
- EXPOSE 9090, ENTRYPOINT, CMD unchanged

Fixes #87