### PR TITLE
refactor: reorder MetricReader trait methods by logical group

### DIFF
--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -18,6 +18,24 @@ pub struct ReaderCapabilities {
 /// Unified interface for reading metrics from any bus protocol.
 #[async_trait]
 pub trait MetricReader: Send + Sync {
+    // ── Connection ──────────────────────────────────────────────────
+
+    /// Establish the underlying connection/transport.
+    async fn connect(&mut self) -> Result<()>;
+
+    /// Close the underlying connection/transport.
+    async fn disconnect(&mut self) -> Result<()>;
+
+    /// Returns `true` when connected.
+    fn is_connected(&self) -> bool;
+
+    // ── Capabilities ────────────────────────────────────────────────
+
+    /// Returns the capabilities of this reader.
+    fn capabilities(&self) -> ReaderCapabilities;
+
+    // ── Read ────────────────────────────────────────────────────────
+
     /// Read a single metric, returning its numeric value.
     async fn read(&mut self, metric: &MetricConfig) -> Result<f64>;
 
@@ -36,16 +54,4 @@ pub trait MetricReader: Send + Sync {
         }
         results
     }
-
-    /// Establish the underlying connection/transport.
-    async fn connect(&mut self) -> Result<()>;
-
-    /// Close the underlying connection/transport.
-    async fn disconnect(&mut self) -> Result<()>;
-
-    /// Returns `true` when connected.
-    fn is_connected(&self) -> bool;
-
-    /// Returns the capabilities of this reader.
-    fn capabilities(&self) -> ReaderCapabilities;
 }


### PR DESCRIPTION
## Summary

Reorders the `MetricReader` trait methods in `src/reader/mod.rs` to follow logical groupings:

1. **Connection group:** `connect()`, `disconnect()`, `is_connected()`
2. **Capabilities group:** `capabilities()`
3. **Read group:** `read()`, `batch_read()`

Added section comments (`// ── Connection ──`, `// ── Capabilities ──`, `// ── Read ──`) for readability.

No impl blocks needed reordering — the protocol modules (i2c, spi, i3c) implement `BusConnection`, not `MetricReader` directly.

**Pure reordering — no logic changes.**

- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test` ✅ (8 passed)

Closes #91