### PR TITLE
refactor: standardize log levels across codebase

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -181,7 +181,7 @@ async fn run_collector(
                 break;
             }
             Err(e) => {
-                error!(error = %e, backoff_secs = backoff.as_secs(), "connection failed, retrying");
+                warn!(error = %e, backoff_secs = backoff.as_secs(), "connection failed, retrying");
                 tokio::select! {
                     _ = tokio::time::sleep(backoff) => {}
                     _ = shutdown_rx.changed() => {
@@ -346,7 +346,7 @@ async fn run_collector(
                         break;
                     }
                     Err(e) => {
-                        error!(error = %e, backoff_secs = backoff.as_secs(), "reconnect failed");
+                        warn!(error = %e, backoff_secs = backoff.as_secs(), "reconnect failed");
                     }
                 }
             }

--- a/src/exporter/mqtt.rs
+++ b/src/exporter/mqtt.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use rumqttc::{AsyncClient, Event, MqttOptions, Packet, QoS, Transport};
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use crate::config::MqttExporterConfig;
 use crate::metrics::MetricStore;
@@ -97,7 +97,7 @@ pub async fn run_mqtt_exporter(
     let endpoint = match &config.endpoint {
         Some(ep) => ep.clone(),
         None => {
-            warn!("mqtt exporter has no endpoint configured");
+            error!("mqtt exporter has no endpoint configured");
             return;
         }
     };
@@ -121,7 +121,7 @@ pub async fn run_mqtt_exporter(
                 mqttoptions.set_transport(Transport::tls_with_config(tls_config));
             }
             Err(e) => {
-                warn!(%e, "failed to build TLS config");
+                error!(%e, "failed to build TLS config");
                 return;
             }
         }


### PR DESCRIPTION
## Summary

Standardizes log levels per the conventions in #101:

- **error**: Actual errors (connection failures, read failures, export failures)
- **warn**: Degraded conditions (reconnect, fallback, timeouts)  
- **info**: Collector lifecycle (start/stop, config loaded, exporter init)
- **debug**: Individual metric reads, protocol-level ops

## Changes

### `src/collector.rs`
- **`connection failed, retrying`**: `error!` → `warn!`  
  Retrying with backoff is a degraded condition, not a terminal error.
- **`reconnect failed`**: `error!` → `warn!`  
  Same rationale — the collector will keep retrying.

### `src/exporter/mqtt.rs`
- **`mqtt exporter has no endpoint configured`**: `warn!` → `error!`  
  Missing endpoint is a fatal config error that prevents the exporter from starting.
- **`failed to build TLS config`**: `warn!` → `error!`  
  TLS config failure is fatal — the exporter cannot proceed.
- Added `tracing::error` to imports.

## Verification
- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅  
- `cargo test` ✅ (8 passed)

Closes #101