### PR TITLE
refactor: standardize log levels and instrument macro levels

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -89,7 +89,7 @@ impl BusClient {
 }
 
 /// Read a single metric from the Modbus client.
-#[instrument(skip(client), fields(metric = %metric.name))]
+#[instrument(level = "debug", skip(client), fields(metric = %metric.name))]
 async fn read_metric(client: &mut dyn ModbusClient, metric: &config::MetricConfig) -> Result<f64> {
     let count = metric.data_type.register_count();
     let data_type = bus::map_data_type(metric.data_type);
@@ -152,7 +152,7 @@ async fn read_bus_metric(client: &mut BusClient, metric: &config::MetricConfig) 
 }
 
 /// Run a single collector loop. This is the core of each collector task.
-#[instrument(skip_all, fields(collector = %collector.name))]
+#[instrument(level = "info", skip_all, fields(collector = %collector.name))]
 async fn run_collector(
     mut client: BusClient,
     collector: config::CollectorConfig,
@@ -181,7 +181,7 @@ async fn run_collector(
                 break;
             }
             Err(e) => {
-                error!(error = %e, backoff_secs = backoff.as_secs(), "connection failed, retrying");
+                warn!(error = %e, backoff_secs = backoff.as_secs(), "connection failed, retrying");
                 tokio::select! {
                     _ = tokio::time::sleep(backoff) => {}
                     _ = shutdown_rx.changed() => {
@@ -252,7 +252,7 @@ async fn run_collector(
                             }
 
                             if !modbus_client.is_connected() {
-                                error!(error = %e, "connection lost during batch poll");
+                                warn!(error = %e, "connection lost during batch poll");
                                 connection_error = true;
                                 poll_had_error = true;
                                 break;
@@ -305,7 +305,7 @@ async fn run_collector(
 
                         // Check if this is a connection-level error
                         if !client.is_connected() {
-                            error!(error = %e, "connection lost during poll");
+                            warn!(error = %e, "connection lost during poll");
                             connection_error = true;
                             poll_had_error = true;
                             break;
@@ -346,7 +346,7 @@ async fn run_collector(
                         break;
                     }
                     Err(e) => {
-                        error!(error = %e, backoff_secs = backoff.as_secs(), "reconnect failed");
+                        warn!(error = %e, backoff_secs = backoff.as_secs(), "reconnect failed");
                     }
                 }
             }

--- a/src/exporter/mqtt.rs
+++ b/src/exporter/mqtt.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use rumqttc::{AsyncClient, Event, MqttOptions, Packet, QoS, Transport};
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use crate::config::MqttExporterConfig;
 use crate::metrics::MetricStore;
@@ -97,7 +97,7 @@ pub async fn run_mqtt_exporter(
     let endpoint = match &config.endpoint {
         Some(ep) => ep.clone(),
         None => {
-            warn!("mqtt exporter has no endpoint configured");
+            error!("mqtt exporter has no endpoint configured");
             return;
         }
     };
@@ -121,7 +121,7 @@ pub async fn run_mqtt_exporter(
                 mqttoptions.set_transport(Transport::tls_with_config(tls_config));
             }
             Err(e) => {
-                warn!(%e, "failed to build TLS config");
+                error!(%e, "failed to build TLS config");
                 return;
             }
         }

--- a/src/exporter/otlp.rs
+++ b/src/exporter/otlp.rs
@@ -287,7 +287,7 @@ impl Backoff {
 ///
 /// The `cancel` token makes backoff sleeps cancellation-aware so shutdown
 /// is not blocked for up to 30 s waiting on a retry delay.
-#[instrument(skip_all)]
+#[instrument(level = "debug", skip_all)]
 async fn send_with_retry(
     client: &reqwest::Client,
     url: &str,
@@ -400,7 +400,7 @@ async fn send_with_retry(
 
 /// Start the periodic OTLP push loop.  Runs until the token is cancelled.
 /// Performs one final flush on shutdown.
-#[instrument(skip_all, fields(endpoint))]
+#[instrument(level = "info", skip_all, fields(endpoint))]
 pub async fn run(
     config: OtlpExporterConfig,
     store: MetricStore,

--- a/src/exporter/prometheus.rs
+++ b/src/exporter/prometheus.rs
@@ -100,7 +100,7 @@ fn render_metrics(store: &MetricStore) -> String {
 }
 
 /// Handler for `/metrics` (or configured path).
-#[instrument(skip_all)]
+#[instrument(level = "debug", skip_all)]
 async fn metrics_handler(State(state): State<Arc<PrometheusState>>) -> impl IntoResponse {
     // Increment scrape counter
     if let Some(ref im) = state.internal_metrics {
@@ -126,7 +126,7 @@ async fn metrics_handler(State(state): State<Arc<PrometheusState>>) -> impl Into
 /// Start the Prometheus scrape HTTP server.
 ///
 /// This function runs until the server is shut down or the process exits.
-#[instrument(skip(store))]
+#[instrument(level = "info", skip(store))]
 pub async fn serve(
     config: &PrometheusExporterConfig,
     store: MetricStore,


### PR DESCRIPTION
## Summary

Standardize log levels across the codebase and add explicit `level` to all `#[instrument]` attributes.

### Changes

**`#[instrument]` macros — explicit levels added:**
- `read_metric` (per-metric read): `level = "debug"`
- `run_collector` (collector lifecycle): `level = "info"`
- `serve` (Prometheus exporter): `level = "info"`
- `metrics_handler` (Prometheus handler): `level = "debug"`
- `send_with_retry` (OTLP retry): `level = "debug"`
- `run` (OTLP exporter): `level = "info"`

**Collector — retryable failures downgraded to `warn!`:**
- Initial connection failure (retrying with backoff)
- Reconnect failure (retrying with backoff)
- Connection lost during poll/batch poll (triggers reconnect)

**MQTT — fatal config errors upgraded to `error!`:**
- No endpoint configured
- Failed to build TLS config

### Log level rules
- **error**: Actual errors (connection failures that skip a collector, export failures)
- **warn**: Degraded conditions (reconnect, fallback, timeouts, retryable failures)
- **info**: Collector lifecycle (start/stop, config loaded, exporter init)
- **debug**: Individual metric reads, protocol-level ops, batch details

Closes #101