### PR TITLE
refactor: rename I2cClient to I2cMetricReader

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -12,7 +12,7 @@ use crate::config::{self, RegisterType};
 use crate::decoder;
 use crate::internal_metrics::InternalMetrics;
 use crate::metrics::{MetricStore, MetricType, MetricValue};
-use crate::reader::i2c::{self, I2cClient};
+use crate::reader::i2c::{self, I2cMetricReader};
 use crate::reader::i3c;
 use crate::reader::modbus::batch::{batch_read_coalesced, BatchReadResult};
 use crate::reader::modbus::{BusConnection, ModbusClient};
@@ -37,7 +37,7 @@ fn map_metric_type(mt: config::MetricType) -> MetricType {
 pub enum BusClient {
     Modbus(Box<dyn ModbusClient>),
     I2c {
-        client: I2cClient,
+        client: I2cMetricReader,
         bus_lock: i2c::BusLock,
     },
     Spi {

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ impl BusClientFactory for RealBusClientFactory {
                 #[cfg(not(target_os = "linux"))]
                 let device: Box<dyn reader::i2c::I2cDevice> = Box::new(reader::i2c::StubI2cDevice);
 
-                let client = reader::i2c::I2cClient::new(device, bus.clone(), *address);
+                let client = reader::i2c::I2cMetricReader::new(device, bus.clone(), *address);
                 // Use shared per-bus lock via get_bus_lock
                 let bus_lock = reader::i2c::get_bus_lock(bus);
                 Ok(BusClient::I2c { client, bus_lock })

--- a/src/reader/i2c/mod.rs
+++ b/src/reader/i2c/mod.rs
@@ -96,8 +96,8 @@ impl I2cDevice for StubI2cDevice {
     }
 }
 
-/// I2C client that wraps a device and provides async read operations.
-pub struct I2cClient {
+/// I2C metric reader that wraps a device and provides async read operations.
+pub struct I2cMetricReader {
     device: Arc<std::sync::Mutex<Box<dyn I2cDevice>>>,
     bus_path: String,
     address: u8,
@@ -116,7 +116,7 @@ pub fn get_bus_lock(bus_path: &str) -> BusLock {
         .clone()
 }
 
-impl I2cClient {
+impl I2cMetricReader {
     pub fn new(device: Box<dyn I2cDevice>, bus_path: String, address: u8) -> Self {
         Self {
             device: Arc::new(std::sync::Mutex::new(device)),
@@ -138,7 +138,7 @@ impl I2cClient {
 
 /// Read a single I2C metric.
 pub async fn read_i2c_metric(
-    client: &I2cClient,
+    client: &I2cMetricReader,
     metric: &config::MetricConfig,
     bus_lock: &BusLock,
 ) -> Result<f64> {
@@ -179,9 +179,9 @@ pub async fn read_i2c_metric(
         .map_err(|e| anyhow::anyhow!("{e}"))
 }
 
-/// Connection/lifecycle trait impl for I2cClient (mirrors BusConnection).
+/// Connection/lifecycle trait impl for I2cMetricReader (mirrors BusConnection).
 #[async_trait]
-impl crate::reader::modbus::BusConnection for I2cClient {
+impl crate::reader::modbus::BusConnection for I2cMetricReader {
     async fn connect(&mut self) -> Result<()> {
         self.connected = true;
         Ok(())

--- a/src/reader/i2c/mod_tests.rs
+++ b/src/reader/i2c/mod_tests.rs
@@ -61,7 +61,7 @@ async fn test_read_u8() {
     let mut responses = HashMap::new();
     responses.insert(0xFA, vec![0x2A]);
     let device = MockI2cDevice::new(responses);
-    let client = I2cClient::new(Box::new(device), "/dev/i2c-1".into(), 0x76);
+    let client = I2cMetricReader::new(Box::new(device), "/dev/i2c-1".into(), 0x76);
 
     let metric = make_metric("temp", 0xFA, DataType::U8);
     let bus_lock = make_bus_lock();
@@ -74,7 +74,7 @@ async fn test_read_u16_big_endian() {
     let mut responses = HashMap::new();
     responses.insert(0xFA, vec![0x01, 0x00]); // 256 in big endian
     let device = MockI2cDevice::new(responses);
-    let client = I2cClient::new(Box::new(device), "/dev/i2c-1".into(), 0x76);
+    let client = I2cMetricReader::new(Box::new(device), "/dev/i2c-1".into(), 0x76);
 
     let metric = make_metric("temp", 0xFA, DataType::U16);
     let bus_lock = make_bus_lock();
@@ -87,7 +87,7 @@ async fn test_read_bool() {
     let mut responses = HashMap::new();
     responses.insert(0x10, vec![0x03]); // bit 0 set
     let device = MockI2cDevice::new(responses);
-    let client = I2cClient::new(Box::new(device), "/dev/i2c-1".into(), 0x48);
+    let client = I2cMetricReader::new(Box::new(device), "/dev/i2c-1".into(), 0x48);
 
     let metric = make_metric("flag", 0x10, DataType::Bool);
     let bus_lock = make_bus_lock();
@@ -100,7 +100,7 @@ async fn test_read_with_scale_offset() {
     let mut responses = HashMap::new();
     responses.insert(0xFA, vec![0x00, 0x64]); // 100 in big endian u16
     let device = MockI2cDevice::new(responses);
-    let client = I2cClient::new(Box::new(device), "/dev/i2c-1".into(), 0x76);
+    let client = I2cMetricReader::new(Box::new(device), "/dev/i2c-1".into(), 0x76);
 
     let mut metric = make_metric("temp", 0xFA, DataType::U16);
     metric.scale = 0.01;
@@ -116,7 +116,7 @@ async fn test_read_with_scale_offset() {
 async fn test_read_register_not_found() {
     let responses = HashMap::new(); // empty
     let device = MockI2cDevice::new(responses);
-    let client = I2cClient::new(Box::new(device), "/dev/i2c-1".into(), 0x76);
+    let client = I2cMetricReader::new(Box::new(device), "/dev/i2c-1".into(), 0x76);
 
     let metric = make_metric("temp", 0xFA, DataType::U8);
     let bus_lock = make_bus_lock();
@@ -143,7 +143,7 @@ async fn test_read_f32() {
     let mut responses = HashMap::new();
     responses.insert(0x20, bytes.to_vec());
     let device = MockI2cDevice::new(responses);
-    let client = I2cClient::new(Box::new(device), "/dev/i2c-1".into(), 0x50);
+    let client = I2cMetricReader::new(Box::new(device), "/dev/i2c-1".into(), 0x50);
 
     let metric = make_metric("pressure", 0x20, DataType::F32);
     let bus_lock = make_bus_lock();

--- a/src/reader/i3c/mod.rs
+++ b/src/reader/i3c/mod.rs
@@ -175,7 +175,7 @@ pub enum AddressMode {
 
 /// I3C client that wraps a device and provides async read operations.
 ///
-/// Unlike `I2cClient`, the I3C client requires `&mut self` for reads because
+/// Unlike `I2cMetricReader`, the I3C client requires `&mut self` for reads because
 /// dynamic address resolution may need to mutate cached state (e.g. after
 /// NACK-triggered re-enumeration). The client is therefore wrapped in
 /// `Arc<tokio::sync::Mutex<..>>` at the call site.


### PR DESCRIPTION
## Summary

Rename `I2cClient` → `I2cMetricReader` to align with the project's MetricReader naming convention (consistent with `SpiMetricReader`, `I3cMetricReader`, etc.).

## Changes

- Renamed struct `I2cClient` → `I2cMetricReader` in `src/reader/i2c/mod.rs`
- Updated doc comments (including BusConnection impl comment)
- Updated all test references in `src/reader/i2c/mod_tests.rs`
- Updated imports and usage in `src/main.rs` and `src/collector.rs`
- Updated cross-reference in `src/reader/i3c/mod.rs` doc comment

## Verification

- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅  
- `cargo test` ✅ (all 227 unit + 27 integration tests pass)

Closes #106