### PR TITLE
refactor: rename SpiClient to SpiMetricReader

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -16,7 +16,7 @@ use crate::reader::i2c::{self, I2cMetricReader};
 use crate::reader::i3c;
 use crate::reader::modbus::batch::{batch_read_coalesced, BatchReadResult};
 use crate::reader::modbus::{BusConnection, ModbusClient};
-use crate::reader::spi::{self, SpiClient};
+use crate::reader::spi::{self, SpiMetricReader};
 
 /// Maximum backoff duration for reconnection attempts.
 const MAX_BACKOFF: Duration = Duration::from_secs(60);
@@ -41,7 +41,7 @@ pub enum BusClient {
         bus_lock: i2c::BusLock,
     },
     Spi {
-        client: SpiClient,
+        client: SpiMetricReader,
         device_lock: spi::DeviceLock,
     },
     I3c {

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ impl BusClientFactory for RealBusClientFactory {
                 let spi_device: Box<dyn reader::spi::SpiDevice> =
                     Box::new(reader::spi::StubSpiDevice);
 
-                let client = reader::spi::SpiClient::new(spi_device, device.clone());
+                let client = reader::spi::SpiMetricReader::new(spi_device, device.clone());
                 let device_lock = reader::spi::get_device_lock(device);
                 Ok(BusClient::Spi {
                     client,

--- a/src/reader/spi/mod.rs
+++ b/src/reader/spi/mod.rs
@@ -97,8 +97,8 @@ impl SpiDevice for StubSpiDevice {
     }
 }
 
-/// SPI client wrapping a device for async read operations.
-pub struct SpiClient {
+/// SPI metric reader that wraps a device for async read operations.
+pub struct SpiMetricReader {
     device: Arc<std::sync::Mutex<Box<dyn SpiDevice>>>,
     device_path: String,
     connected: bool,
@@ -116,7 +116,7 @@ pub fn get_device_lock(device_path: &str) -> DeviceLock {
         .clone()
 }
 
-impl SpiClient {
+impl SpiMetricReader {
     pub fn new(device: Box<dyn SpiDevice>, device_path: String) -> Self {
         Self {
             device: Arc::new(std::sync::Mutex::new(device)),
@@ -137,7 +137,7 @@ impl SpiClient {
 
 /// Read a single SPI metric.
 pub async fn read_spi_metric(
-    client: &SpiClient,
+    client: &SpiMetricReader,
     metric: &config::MetricConfig,
     device_lock: &DeviceLock,
 ) -> Result<f64> {
@@ -183,9 +183,9 @@ pub async fn read_spi_metric(
         .map_err(|e| anyhow::anyhow!("{e}"))
 }
 
-/// Connection/lifecycle trait impl for SpiClient (mirrors BusConnection).
+/// Connection and lifecycle trait implementation for `SpiMetricReader`.
 #[async_trait]
-impl crate::reader::modbus::BusConnection for SpiClient {
+impl crate::reader::modbus::BusConnection for SpiMetricReader {
     async fn connect(&mut self) -> Result<()> {
         self.connected = true;
         Ok(())

--- a/src/reader/spi/mod_tests.rs
+++ b/src/reader/spi/mod_tests.rs
@@ -60,7 +60,7 @@ async fn test_read_u8() {
     let mut responses = HashMap::new();
     responses.insert(vec![0x01], vec![0x2A]);
     let device = MockSpiDevice::new(responses);
-    let client = SpiClient::new(Box::new(device), "/dev/spidev0.0".into());
+    let client = SpiMetricReader::new(Box::new(device), "/dev/spidev0.0".into());
 
     let metric = make_spi_metric("val", vec![0x01], None, 0, DataType::U8);
     let lock = make_device_lock();
@@ -74,7 +74,7 @@ async fn test_read_u16_with_offset() {
     // Command: 3 bytes, response: [0x00, 0x01, 0x00] -> skip byte 0, read u16 from bytes 1-2 = 256
     responses.insert(vec![0x06, 0x00, 0x00], vec![0x00, 0x01, 0x00]);
     let device = MockSpiDevice::new(responses);
-    let client = SpiClient::new(Box::new(device), "/dev/spidev0.0".into());
+    let client = SpiMetricReader::new(Box::new(device), "/dev/spidev0.0".into());
 
     let metric = make_spi_metric("adc", vec![0x06, 0x00, 0x00], Some(3), 1, DataType::U16);
     let lock = make_device_lock();
@@ -87,7 +87,7 @@ async fn test_read_with_scale_offset() {
     let mut responses = HashMap::new();
     responses.insert(vec![0x06, 0x00, 0x00], vec![0x00, 0x00, 0x64]);
     let device = MockSpiDevice::new(responses);
-    let client = SpiClient::new(Box::new(device), "/dev/spidev0.0".into());
+    let client = SpiMetricReader::new(Box::new(device), "/dev/spidev0.0".into());
 
     let mut metric = make_spi_metric("adc", vec![0x06, 0x00, 0x00], Some(3), 1, DataType::U16);
     metric.scale = 0.01;
@@ -117,7 +117,7 @@ async fn test_read_f32() {
     let mut responses = HashMap::new();
     responses.insert(vec![0x01], bytes.to_vec());
     let device = MockSpiDevice::new(responses);
-    let client = SpiClient::new(Box::new(device), "/dev/spidev0.0".into());
+    let client = SpiMetricReader::new(Box::new(device), "/dev/spidev0.0".into());
 
     let metric = make_spi_metric(
         "pressure",
@@ -137,7 +137,7 @@ async fn test_zero_pad_tx_buffer() {
     let mut responses = HashMap::new();
     responses.insert(vec![0x06], vec![0x00, 0x01, 0x00]);
     let device = MockSpiDevice::new(responses);
-    let client = SpiClient::new(Box::new(device), "/dev/spidev0.0".into());
+    let client = SpiMetricReader::new(Box::new(device), "/dev/spidev0.0".into());
 
     let metric = make_spi_metric("adc", vec![0x06], Some(3), 1, DataType::U16);
     let lock = make_device_lock();


### PR DESCRIPTION
Closes #107

## Changes
- Rename `SpiClient` → `SpiMetricReader` in `src/reader/spi/mod.rs`, tests, `main.rs`, and `collector.rs`
- Improve doc comments on the struct and trait impl for clarity
- No functional changes

## Verification
- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test` ✅ (all 8 tests pass)