### PR TITLE
refactor: rename I3cClient to I3cMetricReader

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -45,7 +45,7 @@ pub enum BusClient {
         device_lock: spi::DeviceLock,
     },
     I3c {
-        client: Arc<tokio::sync::Mutex<i3c::I3cClient>>,
+        client: Arc<tokio::sync::Mutex<i3c::I3cMetricReader>>,
         bus_lock: i3c::BusLock,
     },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,7 @@ impl BusClientFactory for RealBusClientFactory {
                 #[cfg(not(target_os = "linux"))]
                 let device: Box<dyn reader::i3c::I3cDevice> = Box::new(reader::i3c::StubI3cDevice);
 
-                let client = reader::i3c::I3cClient::new(device, bus.clone(), address_mode);
+                let client = reader::i3c::I3cMetricReader::new(device, bus.clone(), address_mode);
                 let bus_lock = reader::i3c::get_bus_lock(bus);
                 Ok(BusClient::I3c {
                     client: std::sync::Arc::new(tokio::sync::Mutex::new(client)),

--- a/src/reader/i3c/mod.rs
+++ b/src/reader/i3c/mod.rs
@@ -173,13 +173,13 @@ pub enum AddressMode {
 
 // ── Client ──────────────────────────────────────────────────────────
 
-/// I3C client that wraps a device and provides async read operations.
+/// I3C metric reader that wraps a device and provides async read operations.
 ///
-/// Unlike `I2cMetricReader`, the I3C client requires `&mut self` for reads because
-/// dynamic address resolution may need to mutate cached state (e.g. after
-/// NACK-triggered re-enumeration). The client is therefore wrapped in
+/// Unlike `I2cMetricReader`, the I3C metric reader requires `&mut self` for reads
+/// because dynamic address resolution may need to mutate cached state (e.g. after
+/// NACK-triggered re-enumeration). The reader is therefore wrapped in
 /// `Arc<tokio::sync::Mutex<..>>` at the call site.
-pub struct I3cClient {
+pub struct I3cMetricReader {
     device: Arc<std::sync::Mutex<Box<dyn I3cDevice>>>,
     bus_path: String,
     address_mode: AddressMode,
@@ -268,7 +268,7 @@ fn resolve_address_from_sysfs(address_mode: &AddressMode) -> Result<u8> {
     }
 }
 
-impl I3cClient {
+impl I3cMetricReader {
     pub fn new(device: Box<dyn I3cDevice>, bus_path: String, address_mode: AddressMode) -> Self {
         let resolved = match &address_mode {
             AddressMode::Static(addr) => Some(*addr),
@@ -386,7 +386,7 @@ impl I3cClient {
 
 /// Read a single I3C metric.
 pub async fn read_i3c_metric(
-    client: &Arc<tokio::sync::Mutex<I3cClient>>,
+    client: &Arc<tokio::sync::Mutex<I3cMetricReader>>,
     metric: &config::MetricConfig,
     bus_lock: &BusLock,
 ) -> Result<f64> {

--- a/src/reader/i3c/mod_tests.rs
+++ b/src/reader/i3c/mod_tests.rs
@@ -67,7 +67,7 @@ fn make_metric(
 #[test]
 fn test_static_address_mode() {
     let device = MockI3cDevice::with_fixed_response(vec![0x42]);
-    let mut client = I3cClient::new(
+    let mut client = I3cMetricReader::new(
         Box::new(device),
         "/dev/i3c-0".to_string(),
         AddressMode::Static(0x30),
@@ -79,7 +79,7 @@ fn test_static_address_mode() {
 #[test]
 fn test_pid_address_mode_creation() {
     let device = MockI3cDevice::with_fixed_response(vec![0x42]);
-    let client = I3cClient::new(
+    let client = I3cMetricReader::new(
         Box::new(device),
         "/dev/i3c-0".to_string(),
         AddressMode::Pid("0x0123456789AB".to_string()),
@@ -91,7 +91,7 @@ fn test_pid_address_mode_creation() {
 #[test]
 fn test_device_class_mode_creation() {
     let device = MockI3cDevice::with_fixed_response(vec![0x42]);
-    let client = I3cClient::new(
+    let client = I3cMetricReader::new(
         Box::new(device),
         "/dev/i3c-0".to_string(),
         AddressMode::DeviceClass {
@@ -107,7 +107,7 @@ fn test_device_class_mode_creation() {
 #[test]
 fn test_read_register_static() {
     let device = MockI3cDevice::with_fixed_response(vec![0xAB, 0xCD]);
-    let mut client = I3cClient::new(
+    let mut client = I3cMetricReader::new(
         Box::new(device),
         "/dev/i3c-0".to_string(),
         AddressMode::Static(0x30),
@@ -124,7 +124,7 @@ fn test_nack_triggers_reenumeration() {
     // re-enumeration will also fail. Verify the retry attempt logic.
     let responses: Vec<Result<Vec<u8>>> = vec![Err(anyhow::anyhow!("NACK"))];
     let device = MockI3cDevice::new(responses);
-    let mut client = I3cClient::new(
+    let mut client = I3cMetricReader::new(
         Box::new(device),
         "/dev/i3c-0".to_string(),
         AddressMode::Static(0x30),
@@ -426,7 +426,7 @@ collectors:
 #[tokio::test]
 async fn test_read_i3c_metric_u8() {
     let device = MockI3cDevice::with_fixed_response(vec![0x42]);
-    let client = I3cClient::new(
+    let client = I3cMetricReader::new(
         Box::new(device),
         "/dev/i3c-0".to_string(),
         AddressMode::Static(0x30),
@@ -442,7 +442,7 @@ async fn test_read_i3c_metric_u8() {
 #[tokio::test]
 async fn test_read_i3c_metric_u16_big_endian() {
     let device = MockI3cDevice::with_fixed_response(vec![0x01, 0x00]);
-    let client = I3cClient::new(
+    let client = I3cMetricReader::new(
         Box::new(device),
         "/dev/i3c-0".to_string(),
         AddressMode::Static(0x30),
@@ -458,7 +458,7 @@ async fn test_read_i3c_metric_u16_big_endian() {
 #[tokio::test]
 async fn test_read_i3c_metric_u16_little_endian() {
     let device = MockI3cDevice::with_fixed_response(vec![0x00, 0x01]);
-    let client = I3cClient::new(
+    let client = I3cMetricReader::new(
         Box::new(device),
         "/dev/i3c-0".to_string(),
         AddressMode::Static(0x30),
@@ -475,7 +475,7 @@ async fn test_read_i3c_metric_u16_little_endian() {
 async fn test_read_i3c_metric_f32_big_endian() {
     // IEEE 754: 42.0f32 = 0x42280000
     let device = MockI3cDevice::with_fixed_response(vec![0x42, 0x28, 0x00, 0x00]);
-    let client = I3cClient::new(
+    let client = I3cMetricReader::new(
         Box::new(device),
         "/dev/i3c-0".to_string(),
         AddressMode::Static(0x30),
@@ -491,7 +491,7 @@ async fn test_read_i3c_metric_f32_big_endian() {
 #[tokio::test]
 async fn test_read_i3c_metric_with_scale_offset() {
     let device = MockI3cDevice::with_fixed_response(vec![0x00, 0xF5]); // 245
-    let client = I3cClient::new(
+    let client = I3cMetricReader::new(
         Box::new(device),
         "/dev/i3c-0".to_string(),
         AddressMode::Static(0x30),

--- a/tests/e2e_i3c.rs
+++ b/tests/e2e_i3c.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use bus_exporter::config::{ByteOrder, Config, DataType, MetricConfig, MetricType};
-use bus_exporter::reader::i3c::{AddressMode, I3cClient, I3cDevice};
+use bus_exporter::reader::i3c::{AddressMode, I3cDevice, I3cMetricReader};
 
 // ── Mock Device ─────────────────────────────────────────────────────
 
@@ -149,7 +149,7 @@ collectors:
 #[tokio::test]
 async fn pipeline_u8_metric() {
     let device = MockI3cDevice::fixed(vec![0x42]); // 66
-    let client = I3cClient::new(
+    let client = I3cMetricReader::new(
         Box::new(device),
         "/dev/i3c-0".into(),
         AddressMode::Static(0x30),
@@ -175,7 +175,7 @@ async fn pipeline_u8_metric() {
 async fn pipeline_u16_big_endian_with_scale_offset() {
     // 0x00F5 = 245; 245 * 0.1 + (-40.0) = -15.5
     let device = MockI3cDevice::fixed(vec![0x00, 0xF5]);
-    let client = I3cClient::new(
+    let client = I3cMetricReader::new(
         Box::new(device),
         "/dev/i3c-0".into(),
         AddressMode::Static(0x30),
@@ -201,7 +201,7 @@ async fn pipeline_u16_big_endian_with_scale_offset() {
 async fn pipeline_u16_little_endian() {
     // LE bytes [0x00, 0x01] → 0x0100 = 256
     let device = MockI3cDevice::fixed(vec![0x00, 0x01]);
-    let client = I3cClient::new(
+    let client = I3cMetricReader::new(
         Box::new(device),
         "/dev/i3c-0".into(),
         AddressMode::Static(0x30),
@@ -227,7 +227,7 @@ async fn pipeline_u16_little_endian() {
 async fn pipeline_f32_big_endian() {
     // IEEE 754: 42.0f32 = 0x42280000
     let device = MockI3cDevice::fixed(vec![0x42, 0x28, 0x00, 0x00]);
-    let client = I3cClient::new(
+    let client = I3cMetricReader::new(
         Box::new(device),
         "/dev/i3c-0".into(),
         AddressMode::Static(0x30),
@@ -263,7 +263,7 @@ async fn pipeline_pid_address_mode() {
     // a Static address to exercise the pipeline. The Pid config parsing is
     // already tested above.
     let device = MockI3cDevice::fixed(vec![0xAB]); // 171
-    let client = I3cClient::new(
+    let client = I3cMetricReader::new(
         Box::new(device),
         "/dev/i3c-0".into(),
         AddressMode::Pid("0x0123456789AB".into()),
@@ -295,7 +295,7 @@ async fn pipeline_pid_address_mode() {
 #[tokio::test]
 async fn pipeline_device_class_address_mode() {
     let device = MockI3cDevice::fixed(vec![0x00, 0xC8]); // u16 BE = 200
-    let client = I3cClient::new(
+    let client = I3cMetricReader::new(
         Box::new(device),
         "/dev/i3c-0".into(),
         AddressMode::DeviceClass {
@@ -334,7 +334,7 @@ async fn pipeline_multiple_metrics_sequential() {
     // Two reads: first returns u8=100, second returns u16=0x0200=512
     let responses: Vec<Result<Vec<u8>>> = vec![Ok(vec![0x64]), Ok(vec![0x02, 0x00])];
     let device = MockI3cDevice::new(responses);
-    let client = I3cClient::new(
+    let client = I3cMetricReader::new(
         Box::new(device),
         "/dev/i3c-0".into(),
         AddressMode::Static(0x30),
@@ -367,7 +367,7 @@ fn reenumeration_nack_then_success_static() {
         Ok(vec![0xBE, 0xEF]),
     ];
     let device = MockI3cDevice::new(responses);
-    let mut client = I3cClient::new(
+    let mut client = I3cMetricReader::new(
         Box::new(device),
         "/dev/i3c-0".into(),
         AddressMode::Static(0x30),
@@ -386,7 +386,7 @@ fn reenumeration_all_nack_exhausts_retries() {
         Err(anyhow::anyhow!("NACK")),
     ];
     let device = MockI3cDevice::new(responses);
-    let mut client = I3cClient::new(
+    let mut client = I3cMetricReader::new(
         Box::new(device),
         "/dev/i3c-0".into(),
         AddressMode::Static(0x30),
@@ -407,7 +407,7 @@ async fn async_error_propagation() {
         "sensor offline: device not responding"
     ))];
     let device = MockI3cDevice::new(responses);
-    let client = I3cClient::new(
+    let client = I3cMetricReader::new(
         Box::new(device),
         "/dev/i3c-0".into(),
         AddressMode::Static(0x30),


### PR DESCRIPTION
Rename `I3cClient` → `I3cMetricReader` for consistency with the `I2cMetricReader` naming convention.

### Changes
- Renamed struct `I3cClient` to `I3cMetricReader` in `src/reader/i3c/mod.rs`
- Updated doc comments to refer to "metric reader" instead of "client"
- Updated all references in `mod_tests.rs`, `main.rs`, `collector.rs`, and `tests/e2e_i3c.rs`
- No functional changes

Closes #108