### PR TITLE
refactor: move MetricReaderFactory to reader module, rename to MetricReaderFactoryImpl (#121)

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::Ordering::Relaxed;
 use std::sync::Arc;
@@ -11,7 +10,7 @@ use tracing::{error, info, instrument, warn};
 use crate::config;
 use crate::internal_metrics::InternalMetrics;
 use crate::metrics::{MetricStore, MetricType, MetricValue};
-use crate::reader::{MetricReader, ReadResults};
+use crate::reader::{MetricReader, MetricReaderFactory, ReadResults};
 
 /// Maximum backoff duration for reconnection attempts.
 const MAX_BACKOFF: Duration = Duration::from_secs(60);
@@ -26,12 +25,6 @@ fn map_metric_type(mt: config::MetricType) -> MetricType {
         config::MetricType::Gauge => MetricType::Gauge,
         config::MetricType::Counter => MetricType::Counter,
     }
-}
-
-/// Factory trait for creating metric readers from config.
-/// This allows tests to inject mock clients.
-pub trait MetricReaderFactory: Send + Sync {
-    fn create(&self, collector: &config::CollectorConfig) -> Result<Box<dyn MetricReader>>;
 }
 
 /// Run a single collector loop. This is the core of each collector task.

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,133 +17,12 @@ use clap::Parser;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
-use collector::{CollectorEngine, MetricReaderFactory, DEFAULT_SHUTDOWN_TIMEOUT};
-use config::{find_config_file, Cli, Config, Protocol};
+use collector::{CollectorEngine, DEFAULT_SHUTDOWN_TIMEOUT};
+use config::{find_config_file, Cli, Config};
 use internal_metrics::InternalMetrics;
 use logging::{init_logging, LogOutput, LoggingConfig};
 use metrics::MetricStore;
-use reader::modbus::{rtu::ModbusRtuMetricReader, tcp::ModbusTcpMetricReader};
-
-// ── Real metric reader factory ────────────────────────────────────────
-
-struct RealMetricReaderFactory;
-
-impl MetricReaderFactory for RealMetricReaderFactory {
-    fn create(&self, collector: &config::CollectorConfig) -> Result<Box<dyn reader::MetricReader>> {
-        match &collector.protocol {
-            Protocol::ModbusTcp { endpoint } => {
-                let slave_id = collector.slave_id.unwrap_or(1);
-                Ok(Box::new(ModbusTcpMetricReader::new(
-                    endpoint.clone(),
-                    slave_id,
-                )))
-            }
-            Protocol::ModbusRtu {
-                device,
-                bps,
-                data_bits,
-                stop_bits,
-                parity,
-            } => {
-                let slave_id = collector.slave_id.unwrap_or(1);
-                let builder = tokio_serial::new(device, *bps)
-                    .data_bits(match data_bits {
-                        5 => tokio_serial::DataBits::Five,
-                        6 => tokio_serial::DataBits::Six,
-                        7 => tokio_serial::DataBits::Seven,
-                        _ => tokio_serial::DataBits::Eight,
-                    })
-                    .stop_bits(match stop_bits {
-                        2 => tokio_serial::StopBits::Two,
-                        _ => tokio_serial::StopBits::One,
-                    })
-                    .parity(match parity {
-                        config::Parity::None => tokio_serial::Parity::None,
-                        config::Parity::Even => tokio_serial::Parity::Even,
-                        config::Parity::Odd => tokio_serial::Parity::Odd,
-                    });
-                Ok(Box::new(ModbusRtuMetricReader::new(builder, slave_id)))
-            }
-            Protocol::I2c { bus, address } => {
-                #[cfg(target_os = "linux")]
-                let device: Box<dyn reader::i2c::I2cDevice> = {
-                    let mut dev =
-                        reader::i2c::linux_device::LinuxI2cDevice::new(bus.clone(), *address);
-                    dev.open().context("failed to open I2C device")?;
-                    Box::new(dev)
-                };
-                #[cfg(not(target_os = "linux"))]
-                let device: Box<dyn reader::i2c::I2cDevice> = Box::new(reader::i2c::StubI2cDevice);
-
-                let bus_lock = reader::i2c::get_bus_lock(bus);
-                let client =
-                    reader::i2c::I2cMetricReader::new(device, bus.clone(), *address, bus_lock);
-                Ok(Box::new(client))
-            }
-            Protocol::Spi {
-                device,
-                speed_hz,
-                mode,
-                bits_per_word,
-            } => {
-                #[cfg(target_os = "linux")]
-                let spi_device: Box<dyn reader::spi::SpiDevice> = {
-                    let mut dev = reader::spi::linux_device::LinuxSpiDevice::new(
-                        device.clone(),
-                        *speed_hz,
-                        *mode,
-                        *bits_per_word,
-                    );
-                    dev.open().context("failed to open SPI device")?;
-                    Box::new(dev)
-                };
-                #[cfg(not(target_os = "linux"))]
-                let spi_device: Box<dyn reader::spi::SpiDevice> =
-                    Box::new(reader::spi::StubSpiDevice);
-
-                let device_lock = reader::spi::get_device_lock(device);
-                let client =
-                    reader::spi::SpiMetricReader::new(spi_device, device.clone(), device_lock);
-                Ok(Box::new(client))
-            }
-            Protocol::I3c {
-                bus,
-                pid,
-                address,
-                device_class,
-                instance,
-            } => {
-                let address_mode = if let Some(pid_str) = pid {
-                    reader::i3c::AddressMode::Pid(pid_str.clone())
-                } else if let Some(addr) = address {
-                    reader::i3c::AddressMode::Static(*addr)
-                } else {
-                    reader::i3c::AddressMode::DeviceClass {
-                        class: device_class.clone().unwrap(),
-                        instance: instance.unwrap(),
-                    }
-                };
-
-                #[cfg(target_os = "linux")]
-                let device: Box<dyn reader::i3c::I3cDevice> = {
-                    let mut dev = reader::i3c::linux_device::LinuxI3cDevice::new(bus.clone());
-                    dev.open().context("failed to open I3C device")?;
-                    Box::new(dev)
-                };
-                #[cfg(not(target_os = "linux"))]
-                let device: Box<dyn reader::i3c::I3cDevice> = Box::new(reader::i3c::StubI3cDevice);
-
-                let client = reader::i3c::I3cMetricReader::new(device, bus.clone(), address_mode);
-                let bus_lock = reader::i3c::get_bus_lock(bus);
-                let handle = reader::i3c::I3cMetricReaderHandle::new(
-                    std::sync::Arc::new(tokio::sync::Mutex::new(client)),
-                    bus_lock,
-                );
-                Ok(Box::new(handle))
-            }
-        }
-    }
-}
+use reader::MetricReaderFactoryImpl;
 
 // ── Config → logging mapping ──────────────────────────────────────────
 
@@ -223,7 +102,7 @@ async fn main() -> Result<()> {
     // 5. Spawn collector tasks
     let global_labels: BTreeMap<String, String> =
         config.global_labels.clone().into_iter().collect();
-    let factory = RealMetricReaderFactory;
+    let factory = MetricReaderFactoryImpl;
     let engine = CollectorEngine::spawn(
         config.collectors.clone(),
         store.clone(),

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -5,11 +5,11 @@ pub mod spi;
 
 use std::collections::HashMap;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use tokio_util::sync::CancellationToken;
 
-use crate::config::MetricConfig;
+use crate::config::{self, MetricConfig, Protocol};
 
 /// Check for duplicate metric names and warn about them.
 pub fn warn_duplicate_metric_names(metrics: &[MetricConfig]) {
@@ -63,4 +63,128 @@ pub trait MetricReader: Send {
     /// The `cancel` token allows cooperative cancellation between individual
     /// metric reads for fast shutdown on slow buses.
     async fn read(&mut self, cancel: &CancellationToken) -> ReadResults;
+}
+
+/// Factory trait for creating metric readers from config.
+/// This allows tests to inject mock readers.
+pub trait MetricReaderFactory: Send + Sync {
+    fn create(&self, collector: &config::CollectorConfig) -> Result<Box<dyn MetricReader>>;
+}
+
+/// Default factory implementation that creates real readers based on protocol config.
+pub struct MetricReaderFactoryImpl;
+
+impl MetricReaderFactory for MetricReaderFactoryImpl {
+    fn create(&self, collector: &config::CollectorConfig) -> Result<Box<dyn MetricReader>> {
+        match &collector.protocol {
+            Protocol::ModbusTcp { endpoint } => {
+                let slave_id = collector.slave_id.unwrap_or(1);
+                Ok(Box::new(modbus::tcp::ModbusTcpMetricReader::new(
+                    endpoint.clone(),
+                    slave_id,
+                )))
+            }
+            Protocol::ModbusRtu {
+                device,
+                bps,
+                data_bits,
+                stop_bits,
+                parity,
+            } => {
+                let slave_id = collector.slave_id.unwrap_or(1);
+                let builder = tokio_serial::new(device, *bps)
+                    .data_bits(match data_bits {
+                        5 => tokio_serial::DataBits::Five,
+                        6 => tokio_serial::DataBits::Six,
+                        7 => tokio_serial::DataBits::Seven,
+                        _ => tokio_serial::DataBits::Eight,
+                    })
+                    .stop_bits(match stop_bits {
+                        2 => tokio_serial::StopBits::Two,
+                        _ => tokio_serial::StopBits::One,
+                    })
+                    .parity(match parity {
+                        config::Parity::None => tokio_serial::Parity::None,
+                        config::Parity::Even => tokio_serial::Parity::Even,
+                        config::Parity::Odd => tokio_serial::Parity::Odd,
+                    });
+                Ok(Box::new(modbus::rtu::ModbusRtuMetricReader::new(
+                    builder, slave_id,
+                )))
+            }
+            Protocol::I2c { bus, address } => {
+                #[cfg(target_os = "linux")]
+                let device: Box<dyn i2c::I2cDevice> = {
+                    let mut dev = i2c::linux_device::LinuxI2cDevice::new(bus.clone(), *address);
+                    dev.open().context("failed to open I2C device")?;
+                    Box::new(dev)
+                };
+                #[cfg(not(target_os = "linux"))]
+                let device: Box<dyn i2c::I2cDevice> = Box::new(i2c::StubI2cDevice);
+
+                let bus_lock = i2c::get_bus_lock(bus);
+                let client = i2c::I2cMetricReader::new(device, bus.clone(), *address, bus_lock);
+                Ok(Box::new(client))
+            }
+            Protocol::Spi {
+                device,
+                speed_hz,
+                mode,
+                bits_per_word,
+            } => {
+                #[cfg(target_os = "linux")]
+                let spi_device: Box<dyn spi::SpiDevice> = {
+                    let mut dev = spi::linux_device::LinuxSpiDevice::new(
+                        device.clone(),
+                        *speed_hz,
+                        *mode,
+                        *bits_per_word,
+                    );
+                    dev.open().context("failed to open SPI device")?;
+                    Box::new(dev)
+                };
+                #[cfg(not(target_os = "linux"))]
+                let spi_device: Box<dyn spi::SpiDevice> = Box::new(spi::StubSpiDevice);
+
+                let device_lock = spi::get_device_lock(device);
+                let client = spi::SpiMetricReader::new(spi_device, device.clone(), device_lock);
+                Ok(Box::new(client))
+            }
+            Protocol::I3c {
+                bus,
+                pid,
+                address,
+                device_class,
+                instance,
+            } => {
+                let address_mode = if let Some(pid_str) = pid {
+                    i3c::AddressMode::Pid(pid_str.clone())
+                } else if let Some(addr) = address {
+                    i3c::AddressMode::Static(*addr)
+                } else {
+                    i3c::AddressMode::DeviceClass {
+                        class: device_class.clone().unwrap(),
+                        instance: instance.unwrap(),
+                    }
+                };
+
+                #[cfg(target_os = "linux")]
+                let device: Box<dyn i3c::I3cDevice> = {
+                    let mut dev = i3c::linux_device::LinuxI3cDevice::new(bus.clone());
+                    dev.open().context("failed to open I3C device")?;
+                    Box::new(dev)
+                };
+                #[cfg(not(target_os = "linux"))]
+                let device: Box<dyn i3c::I3cDevice> = Box::new(i3c::StubI3cDevice);
+
+                let client = i3c::I3cMetricReader::new(device, bus.clone(), address_mode);
+                let bus_lock = i3c::get_bus_lock(bus);
+                let handle = i3c::I3cMetricReaderHandle::new(
+                    std::sync::Arc::new(tokio::sync::Mutex::new(client)),
+                    bus_lock,
+                );
+                Ok(Box::new(handle))
+            }
+        }
+    }
 }


### PR DESCRIPTION
## What
- Move `MetricReaderFactory` trait from `src/collector.rs` to `src/reader/mod.rs`
- Move `RealMetricReaderFactory` from `src/main.rs` to `src/reader/mod.rs`, renamed to `MetricReaderFactoryImpl`
- Update imports in main.rs and collector.rs

## Why
The reader factory belongs in the reader module alongside the MetricReader trait — not scattered across collector and main.

Closes #121