### PR TITLE
fix: swap exit codes 1 and 2 for consistency

### DIFF
--- a/spec/cli.md
+++ b/spec/cli.md
@@ -46,7 +46,7 @@ Options:
    d. Call `read()` once.
    e. Call `disconnect()`.
 6. Print JSON to stdout.
-7. Exit code 0 if all reads succeed, 1 if any read fails.
+7. Exit code 0 if all reads succeed, 2 if any read fails.
 
 ### Regex Behavior
 
@@ -222,5 +222,5 @@ enum Command {
 | Code | Meaning |
 |------|---------|
 | 0 | Success (all reads OK for pull) |
-| 1 | Partial failure (some reads failed for pull) |
-| 2 | Fatal error (bad config, bad regex, no matches) |
+| 1 | Fatal error (bad config, bad regex, no matches, no systemd, platform errors) |
+| 2 | Partial failure (some/all metric reads failed for pull) |

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,14 +94,14 @@ async fn main() -> Result<()> {
                 Ok(p) => p,
                 Err(e) => {
                     eprintln!("Fatal: {e:#}");
-                    std::process::exit(2);
+                    std::process::exit(1);
                 }
             };
             let config = match Config::load_for_pull(&config_path) {
                 Ok(c) => c,
                 Err(e) => {
                     eprintln!("Fatal: failed to load configuration: {e:#}");
-                    std::process::exit(2);
+                    std::process::exit(1);
                 }
             };
             let logging_cfg = map_logging_config(&config.logging);
@@ -117,7 +117,7 @@ async fn main() -> Result<()> {
                     Ok(code) => code,
                     Err(e) => {
                         eprintln!("Fatal: {e:#}");
-                        std::process::exit(2);
+                        std::process::exit(1);
                     }
                 };
             std::process::exit(exit_code);

--- a/src/pull.rs
+++ b/src/pull.rs
@@ -166,7 +166,7 @@ pub async fn run_pull(
     println!("{}", serde_json::to_string_pretty(&output)?);
 
     if failed > 0 {
-        Ok(1)
+        Ok(2)
     } else {
         Ok(0)
     }


### PR DESCRIPTION
## Summary

Swap exit codes 1 and 2 to follow a more conventional mapping:

| Code | Before | After |
|------|--------|-------|
| 1 | Partial read failure | **Fatal error** (bad config, bad regex, no matches, no systemd, platform errors) |
| 2 | Fatal error | **Partial read failure** (some/all metric reads failed, e.g. connection refused) |

## Changes

- **src/main.rs**: Changed three `process::exit(2)` calls (config not found, config load failure, pull fatal error) to `exit(1)`
- **src/pull.rs**: Changed `Ok(1)` (partial read failure return) to `Ok(2)`
- **spec/cli.md**: Updated exit code table and pull behavior description to reflect new mapping

## Testing

- `cargo build` ✅
- `cargo test` ✅ (8 passed, 0 failed)