### PR TITLE
Add I2C e2e integration test

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -179,7 +179,7 @@ pub fn generate_config(
                 "    protocol:\n      type: modbus-tcp\n      endpoint: \"{}\"",
                 endpoint
             ),
-            *slave_id,
+            Some(*slave_id),
         ),
         ConnectionParams::ModbusRtu {
             device,
@@ -190,25 +190,35 @@ pub fn generate_config(
                 "    protocol:\n      type: modbus-rtu\n      device: \"{}\"\n      bps: {}",
                 device, bps
             ),
-            *slave_id,
+            Some(*slave_id),
         ),
         ConnectionParams::I2c { bus, address } => (
             format!(
                 "    protocol:\n      type: i2c\n      bus: \"{}\"\n      address: {}",
                 bus, address
             ),
-            0,
+            None, // slave_id is a Modbus-only concept, omit for I2C
         ),
     };
 
     let mut metrics_yaml = String::new();
     for m in &fixtures.metrics {
+        let register_type_line = if m.register_type.is_empty() {
+            String::new()
+        } else {
+            format!("        register_type: {}\n", m.register_type)
+        };
         metrics_yaml.push_str(&format!(
-            "      - name: {}\n        description: \"{}\"\n        type: {}\n        register_type: {}\n        address: {}\n        data_type: {}\n        byte_order: {}\n        scale: {}\n        offset: {}\n        unit: \"{}\"\n",
-            m.name, m.description, m.metric_type, m.register_type, m.address,
+            "      - name: {}\n        description: \"{}\"\n        type: {}\n{}        address: {}\n        data_type: {}\n        byte_order: {}\n        scale: {}\n        offset: {}\n        unit: \"{}\"\n",
+            m.name, m.description, m.metric_type, register_type_line, m.address,
             m.data_type, m.byte_order, m.scale, m.offset, m.unit,
         ));
     }
+
+    let slave_id_line = match slave_id {
+        Some(id) => format!("    slave_id: {}\n", id),
+        None => String::new(),
+    };
 
     let config = format!(
         r#"exporters:
@@ -222,12 +232,11 @@ pub fn generate_config(
 collectors:
   - name: {}
 {}
-    slave_id: {}
-    polling_interval: "1s"
+{}    polling_interval: "1s"
     metrics:
 {}
 "#,
-        collector_name, protocol_yaml, slave_id, metrics_yaml,
+        collector_name, protocol_yaml, slave_id_line, metrics_yaml,
     );
 
     let config_path = dir.join("config.yaml");

--- a/tests/e2e_i2c.rs
+++ b/tests/e2e_i2c.rs
@@ -26,7 +26,7 @@ fn i2c_fixtures() -> TestFixtures {
                 name: "voltage",
                 description: "I2C voltage sensor",
                 metric_type: "gauge",
-                register_type: "holding",
+                register_type: "",
                 address: 0x00,
                 data_type: "u16",
                 byte_order: "big_endian",
@@ -41,7 +41,7 @@ fn i2c_fixtures() -> TestFixtures {
                 name: "temperature",
                 description: "I2C temperature sensor",
                 metric_type: "gauge",
-                register_type: "holding",
+                register_type: "",
                 address: 0x10,
                 data_type: "u16",
                 byte_order: "big_endian",
@@ -109,41 +109,32 @@ fn find_stub_bus() -> Option<PathBuf> {
     None
 }
 
-/// Write a byte value to a register on the i2c-stub device using i2cset.
-/// Uses SMBus byte write: i2cset -y <bus> <addr> <reg> <value>
-fn i2c_write_byte(bus_num: &str, register: u8, value: u8) -> bool {
+/// Write a u16 word value to a register on the i2c-stub device using i2cset word mode.
+/// Uses SMBus word write: i2cset -y <bus> <addr> <reg> <value> w
+fn i2c_write_word(bus_num: &str, register: u8, value: u16) -> bool {
     let status = Command::new("i2cset")
         .args([
             "-y",
             bus_num,
             &format!("0x{:02x}", I2C_STUB_CHIP_ADDR),
             &format!("0x{:02x}", register),
-            &format!("0x{:02x}", value),
+            &format!("0x{:04x}", value),
+            "w",
         ])
         .status();
     matches!(status, Ok(s) if s.success())
 }
 
 /// Write fixture values to the i2c-stub device.
-/// For u16 values, writes high byte at register and low byte at register+1.
+/// Uses SMBus word writes so that smbus_read_word_data can read them back.
 fn write_fixtures_to_stub(bus_num: &str, fixtures: &TestFixtures) -> bool {
     for m in &fixtures.metrics {
         for (i, &raw_word) in m.raw_registers.iter().enumerate() {
-            let base_reg = m.address as u8 + (i as u8 * 2);
-            let hi = (raw_word >> 8) as u8;
-            let lo = (raw_word & 0xFF) as u8;
-            if !i2c_write_byte(bus_num, base_reg, hi) {
+            let reg = m.address as u8 + (i as u8 * 2);
+            if !i2c_write_word(bus_num, reg, raw_word) {
                 eprintln!(
-                    "Failed to write hi byte for metric '{}' at register 0x{:02x}",
-                    m.name, base_reg
-                );
-                return false;
-            }
-            if !i2c_write_byte(bus_num, base_reg + 1, lo) {
-                eprintln!(
-                    "Failed to write lo byte for metric '{}' at register 0x{:02x}",
-                    m.name,
-                    base_reg + 1
+                    "Failed to write word for metric '{}' at register 0x{:02x}",
+                    m.name, reg
                 );
                 return false;
             }


### PR DESCRIPTION
## Summary

Add end-to-end integration test for the I2C protocol reader using the `i2c-stub` kernel module.

### Changes

- **`tests/common/mod.rs`**: Add `ConnectionParams::I2c { bus, address }` variant and handle it in `generate_config()` to produce correct I2C protocol YAML config
- **`tests/e2e_i2c.rs`** (new): E2E test that:
  - Loads the `i2c-stub` kernel module with `chip_addr=0x50`
  - Finds the stub bus by scanning sysfs for the "SMBus stub" adapter
  - Writes u16 test fixture values via `i2cset`
  - Runs `bus-exporter pull` and validates decoded metric values
  - Cleans up with `rmmod i2c-stub` (via Drop guard)
  - Marked `#[ignore]` — requires root + i2c-stub module
  - Skips gracefully when prerequisites are unavailable

### Testing

```bash
# Run with prerequisites (root + i2c-stub):
cargo test --test e2e_i2c -- --ignored

# Regular cargo test skips this automatically
cargo test
```

Closes #141