### PR TITLE
fix: suppress dead_code warnings in shared e2e test module

### DIFF
--- a/tests/e2e_i2c.rs
+++ b/tests/e2e_i2c.rs
@@ -7,6 +7,7 @@
 //! **Requirements:** root privileges, `i2c-stub` kernel module available.
 //! The test is marked `#[ignore]` and skips gracefully when prerequisites are missing.
 
+#[allow(dead_code)]
 mod common;
 
 use common::{ConnectionParams, TestFixtures, TestMetric};

--- a/tests/e2e_modbus.rs
+++ b/tests/e2e_modbus.rs
@@ -4,6 +4,7 @@
 //! config generation, pull execution, and validation. Only the Modbus TCP
 //! simulator (protocol-specific mock) lives here.
 
+#[allow(dead_code)]
 mod common;
 
 use std::collections::HashMap;

--- a/tests/e2e_modbus_rtu.rs
+++ b/tests/e2e_modbus_rtu.rs
@@ -5,6 +5,7 @@
 //!
 //! Requires `socat` and the `serialport` crate's system deps to be installed.
 
+#[allow(dead_code)]
 mod common;
 
 use std::collections::HashMap;

--- a/tests/e2e_spi.rs
+++ b/tests/e2e_spi.rs
@@ -7,6 +7,7 @@
 //! **Requirements:** `/dev/spidev*` device accessible (typically requires root).
 //! The test is marked `#[ignore]` and skips gracefully when no spidev device is found.
 
+#[allow(dead_code)]
 mod common;
 
 use common::{ConnectionParams, TestFixtures, TestMetric};


### PR DESCRIPTION
Each e2e test binary only uses a subset of items from the shared `tests/common/mod.rs` module, causing `dead_code` warnings for unused items (e.g. `raw_registers`, `standard_fixtures`, `ModbusTcp`, `stdout`).

Add `#[allow(dead_code)]` on the `mod common;` declaration in each test file, which is the standard pattern for shared test modules.

**Verified:** `cargo test --test 'e2e_*' -- --include-ignored` produces zero warnings. `cargo fmt --check` passes.