### PR TITLE
refactor: rename `trace` CLI command to `watch`

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,7 +1,7 @@
 pub mod install;
 pub mod pull;
 pub mod run;
-pub mod trace;
+pub mod watch;
 
 use anyhow::Result;
 use regex::Regex;
@@ -45,7 +45,7 @@ pub fn filter_collectors(
     Ok(filtered)
 }
 
-/// Shared collection logic used by both `pull` and `trace`.
+/// Shared collection logic used by both `pull` and `watch`.
 ///
 /// Connects to each collector, reads metrics, and returns JSON objects plus
 /// counters. Returns `(collectors_json, total_metrics, successful, failed)`.

--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -10,8 +10,8 @@ use crate::logging::{init_logging, map_logging_config, LogOutput, LoggingConfig}
 
 use super::{collect_once, filter_collectors};
 
-/// Entry point for the `trace` subcommand.
-pub async fn trace_command(
+/// Entry point for the `watch` subcommand.
+pub async fn watch_command(
     cli_config: Option<&Path>,
     collector: Option<&str>,
     metric: Option<&str>,
@@ -33,11 +33,11 @@ pub async fn trace_command(
         }
     };
     let logging_cfg = map_logging_config(&config.logging);
-    let trace_logging = LoggingConfig {
+    let watch_logging = LoggingConfig {
         level: logging_cfg.level,
         output: LogOutput::Stderr,
     };
-    init_logging(&trace_logging).context("failed to initialize logging")?;
+    init_logging(&watch_logging).context("failed to initialize logging")?;
 
     let mut filtered_collectors = filter_collectors(&config.collectors, collector, metric)?;
     if filtered_collectors.is_empty() {
@@ -81,11 +81,11 @@ pub async fn trace_command(
         cancel_clone.cancel();
     });
 
-    let exit_code = run_trace(&filtered_collectors, loop_interval, &cancel).await;
+    let exit_code = run_watch(&filtered_collectors, loop_interval, &cancel).await;
     std::process::exit(exit_code);
 }
 
-async fn run_trace(
+async fn run_watch(
     collectors: &[CollectorConfig],
     interval: Duration,
     cancel: &CancellationToken,
@@ -134,7 +134,7 @@ async fn run_trace(
 
     // Final summary
     let summary = json!({
-        "trace_summary": {
+        "watch_summary": {
             "total_iterations": iteration,
             "total_successful": total_successful,
             "total_failed": total_failed

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,8 +33,8 @@ pub enum Command {
         #[arg(long)]
         metric: Option<String>,
     },
-    /// Continuous metric tracing — pull in a loop, print to stdout
-    Trace {
+    /// Continuous metric watching — pull in a loop, print to stdout
+    Watch {
         /// Filter collectors by name (regex, partial match)
         #[arg(long)]
         collector: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,12 +19,12 @@ async fn main() -> Result<()> {
             bin,
             uninstall,
         }) => commands::install::run_install(user, config, bin, uninstall),
-        Some(Command::Trace {
+        Some(Command::Watch {
             collector,
             metric,
             interval,
         }) => {
-            commands::trace::trace_command(
+            commands::watch::watch_command(
                 cli.config.as_deref().map(Path::new),
                 collector.as_deref(),
                 metric.as_deref(),


### PR DESCRIPTION
## Summary

Renames the `trace` CLI subcommand to `watch` for clarity.

### Changes
- **src/config.rs** — `Command::Trace` → `Command::Watch`, updated doc comment
- **src/commands/trace.rs → src/commands/watch.rs** — renamed file, `trace_command` → `watch_command`, `run_trace` → `run_watch`
- **src/commands/mod.rs** — `pub mod trace` → `pub mod watch`, updated doc comment
- **src/main.rs** — updated match arm and function call

### Verification
- `cargo fmt --check` ✅
- `cargo build` ✅  
- `cargo test` ✅ (229 passed, 0 failed)