### PR TITLE
refactor: standardize command entry functions to xxx_command naming

### DIFF
--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -21,7 +21,7 @@ WantedBy={wanted_by}
 
 const SERVICE_NAME: &str = "bus-exporter.service";
 
-pub fn run_install(
+pub fn install_command(
     user: bool,
     config_path: Option<PathBuf>,
     bin_path: Option<PathBuf>,

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -37,7 +37,7 @@ pub async fn shutdown_signal() {
 
 // ── Run daemon ────────────────────────────────────────────────────────
 
-pub async fn run_daemon(cli: Cli) -> Result<()> {
+pub async fn run_command(cli: Cli) -> Result<()> {
     let config_path =
         find_config_file(cli.config.as_deref()).context("failed to find configuration file")?;
     let config = Config::load(&config_path).context("failed to load configuration")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<()> {
             config,
             bin,
             uninstall,
-        }) => commands::install::run_install(user, config, bin, uninstall),
+        }) => commands::install::install_command(user, config, bin, uninstall),
         Some(Command::Watch {
             collector,
             metric,
@@ -40,7 +40,7 @@ async fn main() -> Result<()> {
             )
             .await
         }
-        Some(Command::Run) | None => commands::run::run_daemon(cli).await,
+        Some(Command::Run) | None => commands::run::run_command(cli).await,
     }
 }
 


### PR DESCRIPTION
Standardize command entry function names to the `xxx_command` convention:

- `run_install` → `install_command` in `src/commands/install.rs`
- `run_daemon` → `run_command` in `src/commands/run.rs`
- Updated call sites in `src/main.rs`

`pull_command` and `watch_command` already followed this convention.

**Verification:** `cargo fmt --check`, `cargo build`, and `cargo test` all pass (229 tests).