### PR TITLE
ci: skip CI for spec/docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,20 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'spec/**'
+      - '*.md'
+      - 'docs/**'
+      - 'assets/**'
+      - 'config/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'spec/**'
+      - '*.md'
+      - 'docs/**'
+      - 'assets/**'
+      - 'config/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds `paths-ignore` for `spec/**`, `*.md`, and `docs/**` to avoid running full build+test on documentation-only PRs.